### PR TITLE
refactor(jest-typescript-node): simplify config

### DIFF
--- a/patches/jest-typescript-node/package.json
+++ b/patches/jest-typescript-node/package.json
@@ -10,23 +10,9 @@
     "@types/jest": "^24.0.13"
   },
   "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "moduleNameMapper": {
-      "^src/(.*)$": "<rootDir>/$1"
-    },
-    "rootDir": "src",
-    "testRegex": ".spec.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "coverageDirectory": "../coverage",
+    "preset": "ts-jest",
     "collectCoverageFrom": [
-      "**/*.ts"
-    ],
-    "testEnvironment": "node"
+      "src/**/*.ts"
+    ]
   }
 }


### PR DESCRIPTION
Use preset `ts-jest` which handles everything we did manually before.

Closes #4 